### PR TITLE
aggregation improvements 

### DIFF
--- a/data/ChicagoParkDistrict/raw/Standard 18 hr Testing/stack_sheets.R
+++ b/data/ChicagoParkDistrict/raw/Standard 18 hr Testing/stack_sheets.R
@@ -139,6 +139,7 @@ final$Month <- format(final$Full_date,"%B")
 final$Day <- format(final$Full_date, "%d")
 final=final[c(16, 2, 17:19,15, 4:8, 14, 9:13)]
 
+
 #Clean Beach Names
 
 


### PR DESCRIPTION
> handles column name errors in excel files (this is mostly an issue for 2014) and addresses geomeans issue
> imports 2006-2015 same way for each file
> now no need to convert 2015 to .xls
> 
> NOTE: I found three sheets with TWO header columns with incorrect column order (7/6/06, 7/8/06, 7/9/06) -- these are still problematic 
