### PR TITLE
Python cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .Rhistory
 .RData
 *.pyc
+*.pyo

--- a/python_src/read_data.py
+++ b/python_src/read_data.py
@@ -43,8 +43,8 @@ def read_data_simplified():
                         dfs.append(dfx)
                 except KeyError:
                     continue
-                    #print('Trouble processing :', sheet_name, yr)
-                    #checked all trouble sheets and verified bad data
+                    # print('Trouble processing :', sheet_name, yr)
+                    # checked all trouble sheets and verified bad data
     df = pd.concat(dfs)
 
     # Do minimal processing of data
@@ -77,19 +77,17 @@ def read_data_simplified():
     df = df.reset_index()
     df.drop(['index'], axis=1, inplace=True)
 
-    df = cleanUpBeaches(df)
-
     return df
 
 
-def cleanUpBeaches(data):
+def clean_up_beaches(data, beach_names_column='Beach'):
     df = data.copy()
     cpd_data_path = '../data/ChicagoParkDistrict/raw/Standard 18 hr Testing/'
     cleanbeachnames = pd.read_csv(cpd_data_path + 'cleanbeachnames2.csv')
     cleanbeachnames = dict(zip(cleanbeachnames['Old'], cleanbeachnames['New']))
-    df['Beach'] = df['Beach'].map(lambda x: cleanbeachnames[x])
-    df = df.dropna(axis=0,  subset=['Beach'])
-    df['Beach-Date'] = list(map((lambda x,y: str(x)+" : "+str(y)),df.Beach, df.Full_date))
+    df[beach_names_column] = df[beach_names_column].map(lambda x: cleanbeachnames[x])
+    df = df.dropna(axis=0,  subset=[beach_names_column])
+    df['Beach-Date'] = list(map((lambda x,y: str(x)+" : "+str(y)),df[beach_names_column], df.Full_date))
 
     dupIndx=list(df.ix[df.duplicated(['Beach-Date'])].index)
     print('Colapsing {0} records by taking highest reading'.format( len(dupIndx) ))
@@ -108,10 +106,9 @@ def cleanUpBeaches(data):
     return df
 
 
-
-def addColumnPriorData(df, colName , NdaysPrior):
+def add_column_prior_data(df, colName , NdaysPrior):
     import datetime as dt
-    newColName = str(NdaysPrior) + '_daysPrior_'+ colName
+    newColName = str(NdaysPrior) + '_days_prior_'+ colName
     temp = df.ix[:,['Beach','Timestamp',colName]].reset_index()
     temp['TempDate']= df['Timestamp'] + dt.timedelta(days=NdaysPrior)
     temp[newColName] = temp[colName]
@@ -120,11 +117,6 @@ def addColumnPriorData(df, colName , NdaysPrior):
     df.drop(['TempDate'], 1, inplace=True)
 
     return df
-
-
-
-
-
 
 
 def split_sheets(file_name, year, verbose=False):

--- a/python_src/read_data.py
+++ b/python_src/read_data.py
@@ -618,6 +618,7 @@ if __name__ == '__main__':
         df = read_data(args.verbose)
         df.to_csv(args.outfile[0], index=False)
 
+
     if args.test:
         df = read_data(args.verbose)
         print('read_data() returns dataframe with size {0} x {1}'.format(

--- a/python_src/read_data.py
+++ b/python_src/read_data.py
@@ -2,6 +2,7 @@ from __future__ import print_function
 import pandas as pd
 import logging
 import argparse
+import six
 
 '''
 This file reads in data related E. coli levels
@@ -163,7 +164,7 @@ def add_column_prior_data(df, colnames, ns, beach_col_name='Beach', timestamp_co
     >>> df4 = rd.add_column_prior_data(df, ['summary', 'icon'], [1, 2],
     >>>                                beach_col_name='Client.ID', timestamp_col_name='Full_date')
     '''
-    if not hasattr(colnames, '__getitem__') or type(colnames) is str:
+    if not hasattr(colnames, '__getitem__') or isinstance(colnames, six.string_types):
         colnames = [colnames]
     if not hasattr(ns, '__getitem__'):
         ns = [ns]
@@ -484,7 +485,7 @@ def read_data(verbose=False, read_drek=True, read_holiday=True, read_weather_sta
     # Also convert string to float, if possible
     for col in ['Reading.1', 'Reading.2', 'Escherichia.coli']:
         for i, val in enumerate(df[col].tolist()):
-            if type(val) is str:
+            if isinstance(val, six.string_types):
                 val = val.replace('<', '').replace('>', '')
                 try:
                     df.ix[i, col] = float(val)


### PR DESCRIPTION
- Tested with python 2.7 and 3.5
- `add_column_prior_data` function can now take a list of `n` values and a list of column names
- Add some docstrings
- Rudimentary unit tests (just test for completion, not correct values)
  - run with `python read_data.py --test`
- Can pass in argument flags to choose not to download some data (useful for avoiding downloading water/weather station data from data portal)
