### PR TITLE
Cprok data prep clusters

### DIFF
--- a/python_src/read_data.py
+++ b/python_src/read_data.py
@@ -103,11 +103,11 @@ def group_beaches_geographically(data, beach_names_column='Client.ID', verbose=F
     group_3 = ['Oak Street','Ohio','North Ave','North Avenue']
 
     # Near South
-    group_4 = ['12th','31st','39th']
+    group_4 = ['12th','31st']
 
     # Mid South
 
-    group_5 = ['57th','63rd','41st','Oakwood','67th','South Shore','Rainbow', 'Humbolt']
+    group_5 = ['57th','63rd','41st','39th','Oakwood','67th','South Shore','Rainbow', 'Humbolt']
 
     # Calumet is way off to the side.
     group_6 = ['Calumet']

--- a/python_src/read_data.py
+++ b/python_src/read_data.py
@@ -103,7 +103,7 @@ def group_beaches_geographically(data, beach_names_column='Client.ID', verbose=F
     group_3 = ['Oak Street','Ohio','North Ave','North Avenue']
 
     # Near South
-    group_4 = ['12th','31st']
+    group_4 = ['12th','31st','39th']
 
     # Mid South
 
@@ -124,11 +124,6 @@ def group_beaches_geographically(data, beach_names_column='Client.ID', verbose=F
     
     # also want to add single columns, but that is harder.
     df['categorical_beach_grouping'] = df[beach_names_column].map(lambda x: single_grouping(x,all_groups))
-    
-
-    
-
-
 
     return df
 
@@ -144,6 +139,7 @@ def single_grouping(beach_name, groups):
     for beach_group in range(len(groups)):
         if beach_name in groups[beach_group]:
             return 'beach_in_grouping_' + str(beach_group + 1)
+    #print('no category: ' + str(beach_name)) #line used in debugging.
     return 'beach_not_in_any_grouping'
 
 def beach_grouping(beach_name, grouping):

--- a/python_src/read_data.py
+++ b/python_src/read_data.py
@@ -123,8 +123,28 @@ def group_beaches_geographically(data, beach_names_column='Client.ID', verbose=F
     df['flag_geographically_a_north_beach'] = df[beach_names_column].map(lambda x: beach_grouping(x,north_group))
     
     # also want to add single columns, but that is harder.
+    df['categorical_beach_grouping'] = df[beach_names_column].map(lambda x: single_grouping(x,all_groups))
+    
+
+    
+
+
 
     return df
+
+def single_grouping(beach_name, groups):
+    '''Takes list of lists of strings, and sees if thed given beach_name matches any of those.  It then reports which of the initial lists it was in.  If none are found, it returns an N+1th category.
+
+    Inputs
+    ------
+    beach_name: string
+    groups: list of length N, of lists of strings
+    '''
+
+    for beach_group in range(len(groups)):
+        if beach_name in groups[beach_group]:
+            return 'beach_in_grouping_' + str(beach_group + 1)
+    return 'beach_not_in_any_grouping'
 
 def beach_grouping(beach_name, grouping):
     '''Simple function that returns 1 if the beach name is in the applied list.


### PR DESCRIPTION
Two changes here.

1) Added single-variable categorical variable for beach groups, 'categorical_beach_grouping'.  This is by order of groups that is fed into it, which could be cleaned and made less prone to future bugs.
2) 39th street was not handled by categorization.  Fixed.
