### PR TITLE
Updates to modelling framework

### DIFF
--- a/python_src/modeling.py
+++ b/python_src/modeling.py
@@ -336,6 +336,7 @@ if __name__ == '__main__':
         # Parameters that effect computation
         'n_estimators':2000, # even with 2000, still moderate variance between runs
         'max_depth':6,
+        'class_weight': {0: 1.0, 1: 1/.15},
         # Misc parameters
         'n_jobs':-1,
         'verbose':args.verbose

--- a/python_src/modeling.py
+++ b/python_src/modeling.py
@@ -30,13 +30,18 @@ def model(timestamps, predictors, classes,
                  and "predict_proba" at the least.
     hyperparams: Dictionary of hyper parameters to pass to the
                  classifier method.
+    prediction_attribute:
+                 Name of the attribute of the classifier that returns
+                 the probability of belonging to the positive class.
     verbose    : True if the clf.feature_importances_ should be printed
 
     Returns
     -------
-    clfs : Dictionary of (year, classifier) pairs, where the classifier
-           is the model found by leaving the specified year out of the
-           training set.
+    clfs   : Dictionary of (year, classifier) pairs, where the classifier
+             is the model found by leaving the specified year out of the
+             training set.
+    roc_ax : the matplotlib axes object containing all of the ROC curves.
+    pr_ax  : the matplotlib axes object containing all of the PR curves.
     '''
     if classifier is None:
         classifier = sklearn.ensemble.GradientBoostingClassifier

--- a/python_src/modeling.py
+++ b/python_src/modeling.py
@@ -2,6 +2,8 @@ import numpy as np
 import read_data as rd
 import visualizations as viz
 import matplotlib.pyplot as plt
+import argparse
+import pandas as pd
 
 # sklearn imports, may need to add more to use different models
 import sklearn
@@ -309,7 +311,19 @@ def prepare_data(df=None):
 
 
 if __name__ == '__main__':
-    df = rd.read_data(read_weather_station=False, read_water_sensor=False)
+    parser = argparse.ArgumentParser(description='Process beach data.')
+    parser.add_argument('-i', '--input', type=str,
+                        metavar='input_filename', help='input CSV filename')
+    parser.add_argument('-v', '--verbose', action='count', default=0)
+
+    args = parser.parse_args()
+
+    if args.input:
+        df = pd.read_csv(args.input, parse_dates='Full_date')
+        df['Full_date'] = rd.date_lookup(df['Full_date'])
+    else:
+        df = rd.read_data(read_weather_station=False, read_water_sensor=False)
+
     epa_model_df = df[['Drek_Prediction', 'Escherichia.coli']].dropna()
     predictors, meta_info = prepare_data(df)
     timestamps = meta_info['Full_date']
@@ -324,12 +338,12 @@ if __name__ == '__main__':
         'max_depth':6,
         # Misc parameters
         'n_jobs':-1,
-        'verbose':False
+        'verbose':args.verbose
     }
     clfs, roc_ax, pr_ax = model(timestamps, predictors, classes,
                                 classifier=sklearn.ensemble.RandomForestClassifier,
                                 hyperparams=hyperparams,
-                                verbose=True)
+                                verbose=args.verbose)
 
     # Add the EPA model to the ROC and PR curves, prettify
     c = roc_ax.get_lines()

--- a/python_src/visualizations.py
+++ b/python_src/visualizations.py
@@ -8,7 +8,7 @@ import pandas as pd
 TO_BLOCK = True
 
 
-def roc(scores, labels, block_show=TO_BLOCK, ax=None):
+def roc(scores, labels, block_show=TO_BLOCK, ax=None, bounds=None):
     '''
     Plots the Receiver Operator Characteristic (ROC) curve of the results
     from a binary classification system.
@@ -32,6 +32,9 @@ def roc(scores, labels, block_show=TO_BLOCK, ax=None):
     tpr      : Mx1 array of true positive rates
     threshes : Mx1 array of the thresholds on the scores variable
                used to create the corresponding fpr and tpr values.
+    bounds   : [min, max] bounds of the ROC curve, used for setting
+               axis limits as well as computing the AUC. If None, the
+               bounds [0, 1] are used.
 
     Example
     -------
@@ -64,11 +67,18 @@ def roc(scores, labels, block_show=TO_BLOCK, ax=None):
     ax.set_xlabel('False Positive Rate')
     ax.set_ylabel('True Positive Rate')
     ax.set_title('ROC curve')
-    ax.set_aspect('equal')
+    if bounds:
+        ax.set_xlim(bounds)
+        flt = (fpr >= bounds[0]) & (fpr <= bounds[1])
+        ax.set_ylim([0, min(1, max(tpr[flt]) * 1.1)])
+        auc = np.trapz(tpr[flt], x=fpr[flt])
+    else:
+        ax.set_aspect('equal')
+        auc = np.trapz(tpr, x=fpr)
 
+    plt.draw()
     plt.show(block=block_show)
 
-    auc = np.trapz(tpr, x=fpr)
 
     return fpr, tpr, scores[threshold_idxs], auc
 


### PR DESCRIPTION
- All historical variables are now kept as dictionaries so you can specify the exact histories that are used. For example, now you can specify that you want the temperature from every day in the past week, but cloud cover only from yesterday and the day before.
- A little more general in terms of what kinds of classifiers can be easily passed to the main function.
- Adding more variables.
- Consistently outperforming USGS model!
- :warning: Uses the daily summary weather from the _current_ day. To avoid this, comment out the corresponding lines in the definition of the `deterministic_columns` variable in the `process_data` function.
